### PR TITLE
Update projects to .NET 10.0 and add .gitignore

### DIFF
--- a/Calculator.Tests/Calculator.Tests.csproj
+++ b/Calculator.Tests/Calculator.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/Calculator/Calculator.csproj
+++ b/Calculator/Calculator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
This PR updates the Calculator projects to target .NET 10.0 and adds a comprehensive .gitignore file.

## Changes
- ✅ Updated Calculator.csproj to target net10.0
- ✅ Updated Calculator.Tests.csproj to target net10.0  
- ✅ Added .gitignore to exclude build artifacts (bin/, obj/, TestResults/, etc.)
- ✅ All 17 unit tests passing successfully

## Motivation
The dev container has .NET 9.0 and 10.0 installed, but the projects were targeting .NET 8.0 which was not available, causing test execution failures.

## Testing
- Built projects successfully with .NET 10.0
- Ran all unit tests - 17 tests passed (0 failed)